### PR TITLE
Fix IndexOutOfBound exception that occurs at configuration

### DIFF
--- a/src/main/groovy/com/limark/open/gradle/plugins/gitflowsemver/core/strategies/impl/DevelopBranchVersioningStrategy.groovy
+++ b/src/main/groovy/com/limark/open/gradle/plugins/gitflowsemver/core/strategies/impl/DevelopBranchVersioningStrategy.groovy
@@ -74,6 +74,6 @@ class DevelopBranchVersioningStrategy implements VersioningStrategy {
 
   protected String getCommits(gitOutput) {
     def gitSuffixMatcher = (gitOutput =~ /-([0-9]+)-g([0-9a-f]+)$/)
-    return Integer.parseInt(gitSuffixMatcher[0][1].toString())
+    return gitSuffixMatcher.find() ? Integer.parseInt(gitSuffixMatcher[0][1].toString()) : "1"
   }
 }


### PR DESCRIPTION
If you apply this plugin in a fresh develop branch where there are no past commits, an IndexOutOfBounds exception occurs during configuration. This is because the plugin tries to figure out the alpha version by adding 1 to the number of commits, but the operation leads to a -1 as the index.