### PR TITLE
Resolves #7 : Can not execute plugin on tag instead of master branch

### DIFF
--- a/src/main/groovy/com/limark/open/gradle/plugins/gitflowsemver/core/strategies/impl/MasterBranchVersioningStrategy.groovy
+++ b/src/main/groovy/com/limark/open/gradle/plugins/gitflowsemver/core/strategies/impl/MasterBranchVersioningStrategy.groovy
@@ -37,7 +37,7 @@ class MasterBranchVersioningStrategy implements VersioningStrategy {
 
   @Override
   boolean supports(String branch) {
-    return "master" == branch
+    return "master" == branch || gitClient.describeExactMatch().length() > 0
   }
 
   @Override


### PR DESCRIPTION
If the current commit has a matching tag, the plugin use th MasterBranchVersioningStrategy as if it would be on master branch.